### PR TITLE
Enigma remodel

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -2,7 +2,8 @@ require 'pry'
 require 'date'
 require './shift'
 
-class Enigma < Shift
+class Enigma
+  include Shift
   attr_reader :character_set
 
   def initialize
@@ -10,4 +11,5 @@ class Enigma < Shift
   end
 
   def encrypt(message, key, date)
+  end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -4,12 +4,26 @@ require './shift'
 
 class Enigma
   include Shift
-  attr_reader :character_set
+  attr_reader :character_set, :message, :key, :date
 
   def initialize
     @character_set = ("a".."z").to_a << " "
+    @message = ''
+    @key = '02415'
+    @date = Date.today.strftime("%m%d%y")
   end
 
-  def encrypt(message, key, date)
-  end
+  # def encrypt(message, key, date)
+  #   y = []
+  #   x = -1
+  #   find_message_index_positions.each do |position|
+  #     # binding.pry
+  #     y << @character_set.rotate(final_shift[x += 1])[position]
+  #     if x == 3
+  #        x = -1
+  #     end
+  #     # code[position]
+  #   end
+  #   y.join
+  # end
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -1,14 +1,15 @@
 require 'pry'
+require 'date'
 
-class Shift
-  attr_reader :message, :date, :key
-  # attr_accessor :key
+module Shift
+  # attr_reader :message, :date, :key
+  # # attr_accessor :key
 
-  def initialize(message, key, date)
-    @message = message 
-    @key = key
-    @date = date
-  end
+  # def initialize(message, key, date)
+  #   @message = message 
+  #   @key = key
+  #   @date = date
+  # end
 
   def new_key
     @key = 5.times.map{rand(10)}.join 
@@ -39,6 +40,7 @@ class Shift
   end
 
   def date_to_number_squared
+    @date = Date.today.strftime("%m%d%y")
     x = @date.tr('^0-9', '')
     y = x.to_i**2
     y

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -2,15 +2,7 @@ require 'pry'
 require 'date'
 
 module Shift
-  # attr_reader :message, :date, :key
-  # # attr_accessor :key
-
-  # def initialize(message, key, date)
-  #   @message = message 
-  #   @key = key
-  #   @date = date
-  # end
-
+ 
   def new_key
     @key = 5.times.map{rand(10)}.join 
   end
@@ -40,7 +32,6 @@ module Shift
   end
 
   def date_to_number_squared
-    @date = Date.today.strftime("%m%d%y")
     x = @date.tr('^0-9', '')
     y = x.to_i**2
     y

--- a/spec/decryption_spec.rb
+++ b/spec/decryption_spec.rb
@@ -1,40 +1,40 @@
-require 'pry'
-require './lib/enigma'
-require './lib/encryption'
-require './lib/decryption'
+# require 'pry'
+# require './lib/enigma'
+# require './lib/encryption'
+# require './lib/decryption'
 
-RSpec.describe 'Decrypt' do
-  it 'exists' do
-    decrypt = Decrypt.new('ltjsrtj', '02415', '11-11-22')
+# RSpec.describe 'Decrypt' do
+#   it 'exists' do
+#     decrypt = Decrypt.new('ltjsrtj', '02415', '11-11-22')
 
-    expect(decrypt).to be_a(Decrypt)
-    expect(decrypt.message).to eq("ltjsrtj")
-    expect(decrypt.key).to eq('02415')
-    expect(decrypt.date).to eq("11-11-22")
-    expect(decrypt.character_set).to eq([
-                                          "a", "b", "c", "d", "e",
-                                          "f", "g", "h", "i", "j", 
-                                          "k", "l", "m", "n", "o", 
-                                          "p", "q", "r", "s", "t", 
-                                          "u", "v", "w", "x", "y", 
-                                          "z", " "
-                                        ])
-  end
+#     expect(decrypt).to be_a(Decrypt)
+#     expect(decrypt.message).to eq("ltjsrtj")
+#     expect(decrypt.key).to eq('02415')
+#     expect(decrypt.date).to eq("11-11-22")
+#     expect(decrypt.character_set).to eq([
+#                                           "a", "b", "c", "d", "e",
+#                                           "f", "g", "h", "i", "j", 
+#                                           "k", "l", "m", "n", "o", 
+#                                           "p", "q", "r", "s", "t", 
+#                                           "u", "v", "w", "x", "y", 
+#                                           "z", " "
+#                                         ])
+#   end
 
-  describe '#find_message_index_positions' do 
-    it 'will find the index position for every letter in a method based on the character_set attribute' do
-      decrypt = Decrypt.new('ltjsrtj', '02415', '11-11-22')
+#   describe '#find_message_index_positions' do 
+#     it 'will find the index position for every letter in a method based on the character_set attribute' do
+#       decrypt = Decrypt.new('ltjsrtj', '02415', '11-11-22')
 
-      expect(decrypt.find_message_index_positions).to eq([11, 19, 9, 18, 17, 19, 9])
-    end
-  end
+#       expect(decrypt.find_message_index_positions).to eq([11, 19, 9, 18, 17, 19, 9])
+#     end
+#   end
 
-  describe '#decrypt_message' do
-    it 'will decrypt the message' do
-      decrypt = Decrypt.new('ltjsrtj', '02415', '11-11-22')
+#   describe '#decrypt_message' do
+#     it 'will decrypt the message' do
+#       decrypt = Decrypt.new('ltjsrtj', '02415', '11-11-22')
 
-      expect(decrypt.decrypt_message).to eq("boo hoo")
-    end
-  end
+#       expect(decrypt.decrypt_message).to eq("boo hoo")
+#     end
+#   end
 
-end
+# end

--- a/spec/encryption_spec.rb
+++ b/spec/encryption_spec.rb
@@ -1,37 +1,37 @@
-require 'pry'
-require './lib/enigma'
-require './lib/encryption'
+# require 'pry'
+# require './lib/enigma'
+# require './lib/encryption'
 
-RSpec.describe 'Encrypt class' do
-  it 'exists' do
-    encrypt = Encrypt.new('boo hoo', '02415', '11-11-22')
-    expect(encrypt).to be_a(Encrypt)
-    expect(encrypt.message).to eq("boo hoo")
-    expect(encrypt.key).to eq('02415')
-    expect(encrypt.date).to eq("11-11-22")
-    expect(encrypt.character_set).to eq([
-                                          "a", "b", "c", "d", "e",
-                                          "f", "g", "h", "i", "j", 
-                                          "k", "l", "m", "n", "o", 
-                                          "p", "q", "r", "s", "t", 
-                                          "u", "v", "w", "x", "y", 
-                                          "z", " "
-                                        ])
-  end
+# RSpec.describe 'Encrypt class' do
+#   it 'exists' do
+#     encrypt = Encrypt.new('boo hoo', '02415', '11-11-22')
+#     expect(encrypt).to be_a(Encrypt)
+#     expect(encrypt.message).to eq("boo hoo")
+#     expect(encrypt.key).to eq('02415')
+#     expect(encrypt.date).to eq("11-11-22")
+#     expect(encrypt.character_set).to eq([
+#                                           "a", "b", "c", "d", "e",
+#                                           "f", "g", "h", "i", "j", 
+#                                           "k", "l", "m", "n", "o", 
+#                                           "p", "q", "r", "s", "t", 
+#                                           "u", "v", "w", "x", "y", 
+#                                           "z", " "
+#                                         ])
+#   end
 
-  describe '#find_message_index_positions' do 
-    it 'will find the index position for every letter in a method based on the character_set attribute' do
-      encrypt = Encrypt.new('boo hoo', '02415', '11-11-22')
+#   describe '#find_message_index_positions' do 
+#     it 'will find the index position for every letter in a method based on the character_set attribute' do
+#       encrypt = Encrypt.new('boo hoo', '02415', '11-11-22')
 
-      expect(encrypt.find_message_index_positions).to eq([1, 14, 14, 26, 7, 14, 14])
-    end
-  end
+#       expect(encrypt.find_message_index_positions).to eq([1, 14, 14, 26, 7, 14, 14])
+#     end
+#   end
 
-  describe '#encrypt_message' do
-    it 'will encypt the message' do
-      encrypt = Encrypt.new('boo hoo', '02415', '11-11-22')
+#   describe '#encrypt_message' do
+#     it 'will encypt the message' do
+#       encrypt = Encrypt.new('boo hoo', '02415', '11-11-22')
 
-      expect(encrypt.encrypt_message).to eq("ltjsrtj")
-    end
-  end
-end
+#       expect(encrypt.encrypt_message).to eq("ltjsrtj")
+#     end
+#   end
+# end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -4,9 +4,13 @@ require './lib/enigma'
 require './lib/shift'
 
 RSpec.describe 'Enigma class' do
+  let(:enigma) {Enigma.new}
   it 'exists' do
-    enigma = Enigma.new
+
     expect(enigma).to be_a(Enigma)
+    expect(enigma.message).to eq('')
+    expect(enigma.key).to eq('02415')
+    expect(enigma.date).to eq(Date.today.strftime("%m%d%y"))
     expect(enigma.character_set).to eq([
                                           "a", "b", "c", "d", "e",
                                           "f", "g", "h", "i", "j", 
@@ -15,5 +19,54 @@ RSpec.describe 'Enigma class' do
                                           "u", "v", "w", "x", "y", 
                                           "z", " "
                                         ])
+  end
+
+  describe '#a_key' do
+    it 'will return the 1st..5th..9th..etc key in the cipher' do
+
+      expect(enigma.a_key).to eq(02)
+    end
+  end
+
+  describe '#b_key' do
+    it 'will return the 2nd..6th..10th..etc key in the cipher' do
+
+      expect(enigma.b_key).to eq(24)
+    end
+  end
+
+  describe '#c_key' do
+    it 'will return the 3rd..7th..11th..etc key in the cipher' do
+
+      expect(enigma.c_key).to eq(41)
+    end
+  end
+
+  describe '#d_key' do
+    it 'will return the 4th..8th..12th..etc key in the cipher' do
+
+      expect(enigma.d_key).to eq(15)
+    end
+  end
+
+  describe '#date_to_number_squared' do
+    it 'returns the numeric date squared' do
+
+      expect(enigma.date_to_number_squared).to eq(12392587684)
+    end
+  end
+
+  describe '#offset' do
+    it 'will offset the keys based on the last four digits of the square the numeric date' do
+
+      expect(enigma.offset).to eq(["7", "6", "8", "4"])
+    end
+  end
+
+  describe '#final_shift' do
+    it 'returns an array of 4 numbers that represent the cipher shift values' do
+
+      expect(enigma.final_shift).to eq([9, 30, 49, 19])
+    end
   end
 end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -1,6 +1,7 @@
 require 'pry'
 require 'date'
 require './lib/enigma'
+require './lib/shift'
 
 RSpec.describe 'Enigma class' do
   it 'exists' do

--- a/spec/shift_spec.rb
+++ b/spec/shift_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe 'shift class' do
 #     expect(shift.date).to eq("11-11-22")
 #   end
 
-  describe '#new_key' do
-    it 'will randomly genrate a new key and assign it to the attribute key' do
-      # shift = Shift.new('boo hoo', '02415', '11-11-22')
+  # describe '#new_key' do
+  #   it 'will randomly genrate a new key and assign it to the attribute key' do
+  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
-      # shift.new_key
+  #     # shift.new_key
 
-      expect(enigma.new_key).to be_a(String)
-      expect(enigma.new_key.length).to eq(5)
-    end
-  end
+  #     expect(enigma.new_key).to be_a(String)
+  #     expect(enigma.new_key.length).to eq(5)
+  #   end
+  # end
 
   # describe '#a_key' do
   #   it 'will return the 1st..5th..9th..etc key in the cipher' do
@@ -32,7 +32,7 @@ RSpec.describe 'shift class' do
   # end
 
   # describe '#b_key' do
-  #   xit 'will return the 2nd..6th..10th..etc key in the cipher' do
+  #   it 'will return the 2nd..6th..10th..etc key in the cipher' do
   #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
   #     expect(shift.b_key).to eq(24)
@@ -40,7 +40,7 @@ RSpec.describe 'shift class' do
   # end
 
   # describe '#c_key' do
-  #   xit 'will return the 3rd..7th..11th..etc key in the cipher' do
+  #   it 'will return the 3rd..7th..11th..etc key in the cipher' do
   #     shift = Shift.new('boo hoo', '02415', '11-11-22')
 
   #     expect(shift.c_key).to eq(41)
@@ -48,7 +48,7 @@ RSpec.describe 'shift class' do
   # end
 
   # describe '#d_key' do
-  #   xit 'will return the 4th..8th..12th..etc key in the cipher' do
+  #   it 'will return the 4th..8th..12th..etc key in the cipher' do
   #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
   #     expect(shift.d_key).to eq(15)
@@ -56,26 +56,23 @@ RSpec.describe 'shift class' do
   # end
 
   # describe '#date_to_number_squared' do
-  #   xit 'returns the numeric date squared' do
-  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
+  #   it 'returns the numeric date squared' do
 
-  #     expect(shift.date_to_number_squared).to eq(12348098884)
+  #     expect(enigma.date_to_number_squared).to eq(12348098884)
   #   end
   # end
 
   # describe '#offset' do
-  #   xit 'will offset the keys based on the last four digits of the square the numeric date' do
-  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
+  #   it 'will offset the keys based on the last four digits of the square the numeric date' do
 
-  #     expect(shift.offset).to eq(['8', '8', '8', '4'])
+  #     expect(enigma.offset).to eq(['8', '8', '8', '4'])
   #   end
   # end
 
   # describe '#final_shift' do
-  #   xit 'returns an array of 4 numbers that represent the cipher shift values' do
-  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
+  #   it 'returns an array of 4 numbers that represent the cipher shift values' do
 
-  #     expect(shift.final_shift).to eq([10, 32, 49, 19])
+  #     expect(enigma.final_shift).to eq([10, 32, 49, 19])
   #   end
   # end
 

--- a/spec/shift_spec.rb
+++ b/spec/shift_spec.rb
@@ -2,80 +2,81 @@ require 'pry'
 require './lib/shift'
 
 RSpec.describe 'shift class' do
-  it 'exists' do
-    shift = Shift.new('boo hoo', '02415', '11-11-22')
-# binding.pry
-    expect(shift).to be_a(Shift)
-    expect(shift.message).to eq("boo hoo")
-    expect(shift.key).to eq('02415')
-    expect(shift.date).to eq("11-11-22")
-  end
+  let(:enigma) {Enigma.new}
+#   it 'exists' do
+#     shift = Shift.new('boo hoo', '02415', '11-11-22')
+# # binding.pry
+#     expect(shift).to be_a(Shift)
+#     expect(shift.message).to eq("boo hoo")
+#     expect(shift.key).to eq('02415')
+#     expect(shift.date).to eq("11-11-22")
+#   end
 
   describe '#new_key' do
     it 'will randomly genrate a new key and assign it to the attribute key' do
-      shift = Shift.new('boo hoo', '02415', '11-11-22')
+      # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
-      shift.new_key
+      # shift.new_key
 
-      expect(shift.key).to be_a(String)
-      expect(shift.key.length).to eq(5)
+      expect(enigma.new_key).to be_a(String)
+      expect(enigma.new_key.length).to eq(5)
     end
   end
 
-  describe '#a_key' do
-    it 'will return the 1st..5th..9th..etc key in the cipher' do
-      shift = Shift.new('boo hoo', '02415', '11-11-22')
+  # describe '#a_key' do
+  #   it 'will return the 1st..5th..9th..etc key in the cipher' do
+  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
-      expect(shift.a_key).to eq(02)
-    end
-  end
+  #     expect(enigma.a_key).to eq(02)
+  #   end
+  # end
 
-  describe '#b_key' do
-    it 'will return the 2nd..6th..10th..etc key in the cipher' do
-      shift = Shift.new('boo hoo', '02415', '11-11-22')
+  # describe '#b_key' do
+  #   xit 'will return the 2nd..6th..10th..etc key in the cipher' do
+  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
-      expect(shift.b_key).to eq(24)
-    end
-  end
+  #     expect(shift.b_key).to eq(24)
+  #   end
+  # end
 
-  describe '#c_key' do
-    it 'will return the 3rd..7th..11th..etc key in the cipher' do
-      shift = Shift.new('boo hoo', '02415', '11-11-22')
+  # describe '#c_key' do
+  #   xit 'will return the 3rd..7th..11th..etc key in the cipher' do
+  #     shift = Shift.new('boo hoo', '02415', '11-11-22')
 
-      expect(shift.c_key).to eq(41)
-    end
-  end
+  #     expect(shift.c_key).to eq(41)
+  #   end
+  # end
 
-  describe '#d_key' do
-    it 'will return the 4th..8th..12th..etc key in the cipher' do
-      shift = Shift.new('boo hoo', '02415', '11-11-22')
+  # describe '#d_key' do
+  #   xit 'will return the 4th..8th..12th..etc key in the cipher' do
+  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
-      expect(shift.d_key).to eq(15)
-    end
-  end
+  #     expect(shift.d_key).to eq(15)
+  #   end
+  # end
 
-  describe '#date_to_number_squared' do
-    it 'returns the numeric date squared' do
-      shift = Shift.new('boo hoo', '02415', '11-11-22')
+  # describe '#date_to_number_squared' do
+  #   xit 'returns the numeric date squared' do
+  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
-      expect(shift.date_to_number_squared).to eq(12348098884)
-    end
-  end
+  #     expect(shift.date_to_number_squared).to eq(12348098884)
+  #   end
+  # end
 
-  describe '#offset' do
-    it 'will offset the keys based on the last four digits of the square the numeric date' do
-      shift = Shift.new('boo hoo', '02415', '11-11-22')
+  # describe '#offset' do
+  #   xit 'will offset the keys based on the last four digits of the square the numeric date' do
+  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
-      expect(shift.offset).to eq(['8', '8', '8', '4'])
-    end
-  end
+  #     expect(shift.offset).to eq(['8', '8', '8', '4'])
+  #   end
+  # end
 
-  describe '#final_shift' do
-    it 'returns an array of 4 numbers that represent the cipher shift values' do
-      shift = Shift.new('boo hoo', '02415', '11-11-22')
+  # describe '#final_shift' do
+  #   xit 'returns an array of 4 numbers that represent the cipher shift values' do
+  #     # shift = Shift.new('boo hoo', '02415', '11-11-22')
 
-      expect(shift.final_shift).to eq([10, 32, 49, 19])
-    end
-  end
+  #     expect(shift.final_shift).to eq([10, 32, 49, 19])
+  #   end
+  # end
 
 end


### PR DESCRIPTION
Remodels Enigma class and Shift module. Shift needs to be a module for Enigma so that when encrypt and decrypt inevitably interact with enigma in some way, they can have the same access to shift module that Enigma has.